### PR TITLE
sensor definitions update (duplication error)

### DIFF
--- a/sensors/_sony_imx219/imx219.h
+++ b/sensors/_sony_imx219/imx219.h
@@ -26,10 +26,10 @@ typedef struct
 #endif
 
 // Configure formats
-#if EXPECTED_FORMAT == MIPI_DT_RAW10
+#if EXPECTED_FORMAT == _MIPI_DT_RAW10
     #define DATA_FORMAT_REGS raw10_framefmt_regs
 
-#elif EXPECTED_FORMAT == MIPI_DT_RAW8
+#elif EXPECTED_FORMAT == _MIPI_DT_RAW8
     #define DATA_FORMAT_REGS  raw8_framefmt_regs
     
 #endif

--- a/sensors/_sony_imx219/imx219_reg.h
+++ b/sensors/_sony_imx219/imx219_reg.h
@@ -182,13 +182,13 @@ static imx219_settings_t imx219_lanes_regs[] = {
     };
 #endif
 
-#if (CONFIG_MIPI_FORMAT == MIPI_DT_RAW10)
+#if (CONFIG_MIPI_FORMAT == _MIPI_DT_RAW10)
     static imx219_settings_t raw10_framefmt_regs[] = {
         {0x018c, 0x0a},
         {0x018d, 0x0a},
         {0x0309, 0x0a},
     };
-#elif (CONFIG_MIPI_FORMAT == MIPI_DT_RAW8)
+#elif (CONFIG_MIPI_FORMAT == _MIPI_DT_RAW8)
     static imx219_settings_t raw8_framefmt_regs[] = {
         {0x018c, 0x08},
         {0x018d, 0x08},

--- a/sensors/api/sensor.h
+++ b/sensors/api/sensor.h
@@ -17,7 +17,7 @@
 
 // Mipi format and mode
 #ifndef CONFIG_MIPI_FORMAT
-#define CONFIG_MIPI_FORMAT      MIPI_DT_RAW8
+#define CONFIG_MIPI_FORMAT      _MIPI_DT_RAW8
 #endif
 #define MIPI_PKT_BUFFER_COUNT   4 
 
@@ -78,10 +78,10 @@
 #ifndef CONFIG_MIPI_FORMAT
     #error CONFIG_MIPI_FORMAT has to be specified
 #else
-    #if (CONFIG_MIPI_FORMAT == MIPI_DT_RAW10)
+    #if (CONFIG_MIPI_FORMAT == _MIPI_DT_RAW10)
         #define MIPI_IMAGE_WIDTH_BYTES (((MIPI_IMAGE_WIDTH_PIXELS) >> 2) * 5) // by 5/4
 
-    #elif (CONFIG_MIPI_FORMAT == MIPI_DT_RAW8)
+    #elif (CONFIG_MIPI_FORMAT == _MIPI_DT_RAW8)
         #define MIPI_IMAGE_WIDTH_BYTES MIPI_IMAGE_WIDTH_PIXELS // same size
 
     #else

--- a/sensors/api/sensor_defs.h
+++ b/sensors/api/sensor_defs.h
@@ -7,8 +7,8 @@
 #define MODE_WQSXGA_3280x2464    0x03
 #define MODE_FHD_1920x1080       0x04
 
-#define MIPI_DT_RAW8             0x2A
-#define MIPI_DT_RAW10            0x2B
+#define _MIPI_DT_RAW8            0x2A
+#define _MIPI_DT_RAW10           0x2B
 
-#define BIAS_DISABLED           0x00  // no demux
-#define BIAS_ENABLED            0x80  // bias
+#define BIAS_DISABLED            0x00  // no demux
+#define BIAS_ENABLED             0x80  // bias


### PR DESCRIPTION
There is an enum in mipi with the same naming as the internal sensor definition, I replaced the internal sensor definition with an underscore. 