### PR TITLE
werror private to fwk_camera

### DIFF
--- a/camera/CMakeLists.txt
+++ b/camera/CMakeLists.txt
@@ -28,7 +28,7 @@ target_sources(${LIB_NAME}
 )
 
 target_compile_options(${LIB_NAME}
-  PUBLIC
+  PRIVATE
     -Os
     -Wall
     -Werror

--- a/sensors/CMakeLists.txt
+++ b/sensors/CMakeLists.txt
@@ -39,8 +39,9 @@ target_sources(${LIB_NAME}
 )
 
 target_compile_options(${LIB_NAME}
-    PUBLIC
-        -Wall -Werror
+    PRIVATE
+        -Wall 
+        -Werror
 )
 
 target_link_libraries(${LIB_NAME} PUBLIC lib_i2c)


### PR DESCRIPTION
tflite micro has warnings due to model size and cpp, changing to private to do not affect -Werror option of fwk_camera to sln_vision