### PR TITLE
update xjsl to 0.27

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.26.0')
+@Library('xmos_jenkins_shared_library@v0.27.0')
 
 def runningOn(machine) {
   println "Stage running on:"
@@ -19,7 +19,7 @@ pipeline {
   options {
     skipDefaultCheckout()
     timestamps()
-    buildDiscarder(xmosDiscardBuildSettings())
+    buildDiscarder(xmosDiscardBuildSettings(onlyArtifacts=false))
   } // options
 
   stages {


### PR DESCRIPTION
- [ ] double check about released master builds and keep forever
- [x] add the `pr:keepallbuilds` label


This PR introduces/updates a method for automatically deleting Jenkins builds after a certain time/number. This is needed so that Jenkins disk does not forever grow.

Please understand that **THIS IS A DESTRUCTIVE CHANGE** and once merged will permanently delete old builds so please come forward with any concerns over the settings chosen if you have any.

We will use the [buildDiscarder Jenkinsfile option](https://stackoverflow.com/questions/39542485/how-to-write-pipeline-to-discard-old-builds/44155346#44155346) to configure this using the [xmosDiscardBuildSettings function](https://github.com/xmos/xmos_jenkins_shared_library/pull/331).

------------------------

[Here is a link to the confluence page](https://xmosjira.atlassian.net/wiki/spaces/wiki/pages/3396534277/Build+Discarding) going into more detail about justification and usage.

The short version is:

- develop: 16 days
- main/master/release: 10 builds
- PR/branch/other: 30 builds

Please comment if you think this is unsuitable.


------------------------

### Overriding

Single builds can be kept using the "keep this build forever" button on Jenkins. We suggest using this to tag builds that releases have been made from.

We also introduced the PR label `pr:keepallbuilds`, this will override the "30" build limit for specific PRs.

------------------------

PS I have also opted to use this opportunity to add the timestamps option to jobs that do not already employ it. This makes it easier to diagnose any future Jenkins issues.

