### PR TITLE
fixing external deps as top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,7 @@ set(CONFIG_MIPI_FORMAT ${CONFIG_RAW8})
 
 ## Add frameworks
 add_subdirectory(modules)
-if(PROJECT_IS_TOP_LEVEL)
-  add_subdirectory(external_deps)
-endif()
+add_subdirectory(external_deps)
 
 ## Add sensors
 add_subdirectory(sensors)

--- a/external_deps/CMakeLists.txt
+++ b/external_deps/CMakeLists.txt
@@ -1,5 +1,7 @@
-# Fetch library
 include(FetchContent)
+
+# Fetch library
+message(STATUS "Fetching: fwk_camera_deps/fwk_io")
 FetchContent_Declare(
   fwk_io
   GIT_REPOSITORY https://github.com/xmos/fwk_io


### PR DESCRIPTION
Changes:
1. The module 'fwk_io' is required outside the top level. 
2. When fetching, a small CMake message will be displayed to signal that the module is being fetched. 