### PR TITLE
Fix lib_i2c userguide link format

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ def checkSkipLink() {
 
 def buildDocs(String zipFileName) {
   withVenv {
-    sh 'pip install git+ssh://git@github.com/xmos/xmosdoc@v5.1.1'
+    sh 'pip install git+ssh://git@github.com/xmos/xmosdoc@v5.2.0'
     sh "xmosdoc ${checkSkipLink()}"
     zip zipFile: zipFileName, archive: true, dir: "doc/_build"
   }

--- a/doc/substitutions.inc
+++ b/doc/substitutions.inc
@@ -1,7 +1,7 @@
 
 .. _MIPI: https://www.mipi.org/specifications/csi-2
 .. _XMOS: https://www.xmos.ai/
-.. _XMOS I2C: https://www.xmos.ai/download/lib_i2c-%5Buserguide%5D(5.0.0rc3).pdf
+.. _XMOS I2C: https://www.xmos.ai/download/lib_i2c-userguide(5_0_0rc3).pdf
 .. _XMOS Programming Guide: https://www.xmos.ai/download/XMOS-Programming-Guide-(documentation)(E).pdf
 .. _IMX219: https://www.opensourceinstruments.com/Electronics/Data/IMX219PQ.pdf
 .. _SW_TOOLS: https://www.xmos.ai/software-tools/


### PR DESCRIPTION
Seems the website updated the link format. I'd also like to turn this green so I can run an unrelated test.