### PR TITLE
Fixing camera i2c debug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,3 +77,4 @@ lib_camera change log
   * ADDED: cropping / scaling : image scalling, cropping.
   * ADDED: Image statistics: histogram, mean, variance, skewness.
   * ADDED: sensor control, start, stop functons.
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,11 @@ lib_camera change log
 
   * ADDED: fast int8 to uint8 conversion.
   * ADDED: continous AE control (-DCONFIG_APPLY_AE=2).
-  * CHANGED: Default MIPI PHY and SHIM frecuency to 150MHz.
+  * CHANGED: Default MIPI PHY and SHIM frequency to 150MHz.
+
+  * Changes to dependencies:
+
+    - lib_logging: 3.3.1 -> 3.4.0
 
 2.0.0
 -----
@@ -73,4 +77,3 @@ lib_camera change log
   * ADDED: cropping / scaling : image scalling, cropping.
   * ADDED: Image statistics: histogram, mean, variance, skewness.
   * ADDED: sensor control, start, stop functons.
-

--- a/doc/rst/04_configuration.rst
+++ b/doc/rst/04_configuration.rst
@@ -14,8 +14,9 @@ Logging Options
 
 The library provides a logging mechanism to help developers debug and monitor the camera's operation. The logging options are available via CMake options. The following options are available:
 
-- -DDEBUG_PRINT_ENABLE_CAM_ISP=1 : This option enables debug prints for the ISP thread. It can be used to monitor the status of the ISP and its components.
-- -DDEBUG_PRINT_ENABLE_CAM_MIPI=1 : This option enables debug prints for the MIPI thread. It can be used to monitor the status of the MIPI receiver and its components.
+- -DDEBUG_PRINT_ENABLE_CAM_ISP=1 : This option enables debug prints for the ISP thread. It can be used to monitor the status of the ISP and its components. Disabled by default.
+- -DDEBUG_PRINT_ENABLE_CAM_MIPI=1 : This option enables debug prints for the MIPI thread. It can be used to monitor the status of the MIPI receiver and its components. Disabled by default.
+- -DDEBUG_PRINT_ENABLE_CAM_I2C=1 : This option enables debug prints for the I2C communication. It can be used to monitor the I2C transactions between the camera sensor and the ISP. Disabled by default.
 - -DCONFIG_APPLY_AE=1: This option enables the application of automatic exposure (AE) settings (default). It can be set to 0 to disable AE. Setting it to 2 enables continuous AE adjustment.
 - -DCONFIG_APPLY_AWB=1: This option enables the application of automatic white balance (AWB) settings (default). It can be set to 0 to disable AWB.
 - -DLIBXCORE_XASSERT_IS_ASSERT=1 : This option configures the library to use the standard ``assert`` C standard library instead of ``lib_xcore/xassert`` for runtime exceptions. Enabling this provides more detailed error reporting, as ``assert`` outputs information about the error location, while ``xassert`` does not. Default is set to 0.

--- a/lib_camera/lib_build_info.cmake
+++ b/lib_camera/lib_build_info.cmake
@@ -1,6 +1,6 @@
 set(LIB_NAME lib_camera)
 set(LIB_VERSION 2.0.1)
-set(LIB_DEPENDENT_MODULES i2c "lib_logging(3.3.1)")
+set(LIB_DEPENDENT_MODULES i2c "lib_logging(3.4.0)")
 set(LIB_INCLUDES api src src/sensors src/isp)
 set(LIB_COMPILER_FLAGS -Os -Wall -g -fxscope -mcmodel=large -Werror)
 

--- a/lib_camera/src/sensors/sensor_base.cpp
+++ b/lib_camera/src/sensors/sensor_base.cpp
@@ -1,10 +1,14 @@
 // Copyright 2023-2025 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
-#include <print.h>
 
 #include "sensor_base.hpp"
 #include "camera_utils.h"
+
+// debug options
+// (can be enabled via: -DDEBUG_PRINT_ENABLE_CAM_I2C=1)
+#define DEBUG_UNIT CAM_I2C 
+#include <debug_print.h>
 
 using namespace sensor;
 
@@ -19,7 +23,7 @@ void SensorBase::i2c_init() {
     this->i2c_cfg.p_sda, 0, 0xC,
     this->i2c_cfg.speed);
   delay_milliseconds_cpp(100);
-  printstrln("I2C initialized.");
+  debug_printf("I2C initialized.\n");
 }
 
 int SensorBase::i2c_read(uint16_t reg) {
@@ -64,9 +68,7 @@ int SensorBase::i2c_write_table(i2c_table_t table) {
     // pause if we reset the device
     if (address == sleep_adr) {
       delay_ticks_cpp(sleep_ticks);
-      #if PRINT_I2C_REG
-        printf("sleeping...\n");
-      #endif
+      debug_printf("sleep for %d ticks\n", sleep_ticks);
     }
 
     // if continuous mode
@@ -74,17 +76,13 @@ int SensorBase::i2c_write_table(i2c_table_t table) {
       if (address & 0x8000) {
         address &= 0x7fff;
       }
-      #if PRINT_I2C_REG
-        printf("mode=%c , address  = 0x%04x, value = 0x%02x\n", 'c', address, value >> 8);
-        printf("mode=%c , address+ = 0x%04x, value = 0x%02x\n", 'c', address+1, value & 0xff);  
-      #endif 
+      debug_printf("mode=%c , address  = 0x%04x, value = 0x%02x\n", 'c', address, value >> 8);
+      debug_printf("mode=%c , address+ = 0x%04x, value = 0x%02x\n", 'c', address+1, value & 0xff);
       ret |= this->i2c_write_line(address,   value >> 8); // B1 B2 B3 B4 -> B1 B2
       ret |= this->i2c_write_line(address+1, value & 0xff); // B1 B2 B3 B4 -> B3 B4 
     }
     else {
-      #if PRINT_I2C_REG
-        printf("mode=%c , address = 0x%04x, value = 0x%02x\n", 's', address, value);
-      #endif
+      debug_printf("mode=%c , address = 0x%04x, value = 0x%02x\n", 's', address, value);
       ret |= this->i2c_write_line(address, (uint8_t)value);
     }
   }

--- a/lib_camera/src/sensors/sensor_wrapper.cpp
+++ b/lib_camera/src/sensors/sensor_wrapper.cpp
@@ -11,7 +11,6 @@
 #include "sensor_base.hpp"
 #include "camera_utils.h"
 
-
 #include "sensor_imx219.hpp"
 
 using namespace sensor;
@@ -44,7 +43,6 @@ void camera_sensor_init() {
     (centralise_t)CONFIG_CENTRALISE);
 
   // Init the I2C sensor first configuration
-  debug_printf("Camera init\n");
   int ret = 0;
   ret |= camera_sensor_ptr->initialize();
   delay_milliseconds_cpp(100);
@@ -53,7 +51,6 @@ void camera_sensor_init() {
   ret |= camera_sensor_ptr->stream_start();
   delay_milliseconds_cpp(500);
   xassert((ret == 0) && "Could not initialise camera");
-  debug_printf("Camera_started and configured\n");
 }
 
 void camera_sensor_start() {

--- a/lib_camera/src/sensors/sensor_wrapper.h
+++ b/lib_camera/src/sensors/sensor_wrapper.h
@@ -13,7 +13,6 @@
 // I2C defines
 #define I2C_DEV_ADDR             0x10
 #define I2C_DEV_SPEED             400
-#define PRINT_I2C_REG               0
 
 // Sensor defines
 typedef struct {


### PR DESCRIPTION
- Removes hardcoded PRINT_I2C_REG define with lib_logging debug_printf calls
- Updates lib_logging 3.3.1 to 3.4.0
- Adds documentation for the new DEBUG_PRINT_ENABLE_CAM_I2C CMake option